### PR TITLE
Add multiversion support - both dstu2 and stu3 now supported

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     fhir_scorecard (3.0.1)
+      fhir_dstu2_models
       fhir_models (>= 3.0.0)
 
 GEM
@@ -15,12 +16,17 @@ GEM
     coderay (1.1.1)
     date_time_precision (0.8.1)
     docile (1.1.5)
+    fhir_dstu2_models (1.0.2)
+      bcp47 (>= 0.3)
+      date_time_precision (>= 0.8)
+      mime-types (>= 1.16, < 3)
+      nokogiri (>= 1.7)
     fhir_models (3.0.1)
       bcp47 (>= 0.3)
       date_time_precision (>= 0.8)
       mime-types (>= 1.16, < 3)
       nokogiri (>= 1.6)
-    i18n (0.8.1)
+    i18n (0.8.4)
     json (2.0.3)
     method_source (0.8.2)
     mime-types (2.99.3)
@@ -31,7 +37,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    nokogiri (1.7.1)
+    nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
     pry (0.10.4)
       coderay (~> 1.1.0)

--- a/fhir_scorecard.gemspec
+++ b/fhir_scorecard.gemspec
@@ -12,4 +12,5 @@ Gem::Specification.new do |s|
   s.files = s.files = `git ls-files`.split("\n")
 
   s.add_runtime_dependency 'fhir_models', '>= 3.0.0'
+  s.add_runtime_dependency 'fhir_dstu2_models'
 end

--- a/lib/fhir_helper.rb
+++ b/lib/fhir_helper.rb
@@ -1,0 +1,21 @@
+module FHIR
+  # check whether the given object is an instance of any version of the given resource type
+  # if you only care about a single version, don't use this, just use x.is_a?(FHIR::Whatever)
+  def self.is_any_version?(object, resource_type)
+    # resource type should be a string
+    # TODO: maybe expand this to accept a map, ex { dstu2: 'MedicationOrder', stu3: 'MedicationRequest' }
+
+    classnames = ["FHIR::#{resource_type}", "FHIR::DSTU2::#{resource_type}"]
+
+    classnames.any? do |classname|
+      klass = Object.const_defined?(classname) && Object.const_get(classname) # get the class for the name
+      # note that there may not be a class with that name, in which case const_defined => false
+      klass && object.is_a?(klass)
+    end
+  end
+
+  # shorter version for this one class that is used all over the place
+  def self.is_model?(object)
+    object.is_a?(FHIR::Model) || object.is_a?(FHIR::DSTU2::Model)
+  end
+end

--- a/lib/fhir_scorecard.rb
+++ b/lib/fhir_scorecard.rb
@@ -1,6 +1,7 @@
 # Top level include file that brings in all the necessary code
 require 'bundler/setup'
 require 'fhir_models'
+require 'fhir_dstu2_models'
 
 root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
 
@@ -8,6 +9,7 @@ require File.join(root,'lib','scorecard.rb')
 require File.join(root,'lib','terminology.rb')
 require File.join(root,'lib','implementation_guides.rb')
 require File.join(root,'lib','rubrics.rb')
+require File.join(root,'lib','fhir_helper.rb')
 
 Dir.glob(File.join(root, 'lib','rubrics','**','*.rb')).each do |file|
   require file

--- a/lib/rubrics/codes_exist.rb
+++ b/lib/rubrics/codes_exist.rb
@@ -45,9 +45,9 @@ module FHIR
           value = fhir_model.instance_variable_get("@#{field_name}")
           if !value.nil?
             if value.is_a?(Array)
-              value.each{|v| results.merge!(check_metadata(v)){|k,a,b|a+b} if v.is_a?(FHIR::Model)}
+              value.each{|v| results.merge!(check_metadata(v)){ |k,a,b|a+b} if FHIR.is_model?(v) }
             else # not an Array
-              results.merge!(check_metadata(value)){|k,a,b|a+b} if value.is_a?(FHIR::Model)
+              results.merge!(check_metadata(value)){|k,a,b|a+b} if FHIR.is_model?(value)
             end
           end            
         end
@@ -60,9 +60,9 @@ module FHIR
       when 'code'
         item.is_a?(String)
       when 'Coding'
-        item.is_a?(FHIR::Coding) && !item.code.nil? && !item.system.nil?
+        FHIR.is_any_version?(item, 'Coding') && !item.code.nil? && !item.system.nil?
       when 'CodeableConcept'
-        item.is_a?(FHIR::CodeableConcept) && item.coding.any?{|c| c.is_a?(FHIR::Coding) && !c.code.nil? && !c.system.nil?}
+        FHIR.is_any_version?(item, 'CodeableConcept') && item.coding.any?{ |c| FHIR.is_any_version?(c, 'Coding') && !c.code.nil? && !c.system.nil? }
       else
         false
       end

--- a/lib/rubrics/codes_umls.rb
+++ b/lib/rubrics/codes_umls.rb
@@ -57,9 +57,9 @@ module FHIR
           end
         elsif !value.nil?
           if value.is_a?(Array)
-            value.each{|v| results.merge!(check_fields(v)){|k,a,b|a+b} if v.is_a?(FHIR::Model)}
+            value.each{|v| results.merge!(check_fields(v)){|k,a,b|a+b} if FHIR.is_model?(v) }
           else # not an Array
-            results.merge!(check_fields(value)){|k,a,b|a+b} if value.is_a?(FHIR::Model)
+            results.merge!(check_fields(value)){|k,a,b|a+b} if FHIR.is_model?(value)
           end
         end
       end

--- a/lib/rubrics/codes_umls_preferred_descriptions.rb
+++ b/lib/rubrics/codes_umls_preferred_descriptions.rb
@@ -57,9 +57,9 @@ module FHIR
           end
         elsif !value.nil?
           if value.is_a?(Array)
-            value.each{|v| results.merge!(check_fields(v)){|k,a,b|a+b} if v.is_a?(FHIR::Model)}
+            value.each{|v| results.merge!(check_fields(v)){|k,a,b|a+b} if FHIR.is_model?(v)}
           else # not an Array
-            results.merge!(check_fields(value)){|k,a,b|a+b} if value.is_a?(FHIR::Model)
+            results.merge!(check_fields(value)){|k,a,b|a+b} if FHIR.is_model?(value)
           end
         end
       end

--- a/lib/rubrics/completeness.rb
+++ b/lib/rubrics/completeness.rb
@@ -12,14 +12,20 @@ module FHIR
       'QuestionnaireResponse','Coverage'
     ]
 
-    MEDICATIONS = [ 'MedicationStatement','MedicationDispense','MedicationAdministration','MedicationRequest' ]
+    COMMON_MEDICATIONS = [ 'MedicationStatement','MedicationDispense','MedicationAdministration']
+
+    DSTU2_MEDICATIONS = COMMON_MEDICATIONS + ['MedicationOrder']
+
+    STU3_MEDICATIONS = COMMON_MEDICATIONS + ['MedicationRequest']
 
     # A Patient Record is not complete without certain required items and medications.
     rubric :completeness do |record|
       
+      curr_version_meds = record.is_a?(FHIR::Model) ? STU3_MEDICATIONS : DSTU2_MEDICATIONS
+
       missing_required = REQUIRED.clone
       missing_expected = EXPECTED.clone
-      missing_meds = MEDICATIONS.clone
+      missing_meds = curr_version_meds.clone
 
       resources = record.entry.map{|e|e.resource}
       resources.each do |resource|
@@ -32,7 +38,7 @@ module FHIR
 
       # 15 points for required resources
       numerator = (REQUIRED.length.to_f - missing_required.length.to_f)
-      numerator += 1 if (missing_meds.length < MEDICATIONS.length)
+      numerator += 1 if (missing_meds.length < curr_version_meds.length)
       denominator = REQUIRED.length.to_f + 1.0 # add one for medications
       percentage_required = (  numerator / denominator )
       percentage_required = 0.0 if percentage_required.nan?

--- a/lib/rubrics/cvx_immunizations.rb
+++ b/lib/rubrics/cvx_immunizations.rb
@@ -10,7 +10,7 @@ module FHIR
 
       resources = record.entry.map{|e|e.resource}
       resources.each do |resource|
-        if resource.is_a?(FHIR::Immunization)
+        if FHIR.is_any_version?(resource, 'Immunization')
             results[:eligible_fields] += 1
             results[:validated_fields] += 1 if cvx?(resource.vaccineCode)        
         end

--- a/lib/rubrics/cvx_meds.rb
+++ b/lib/rubrics/cvx_meds.rb
@@ -10,19 +10,20 @@ module FHIR
       # Medication.code (CodeableConcept)
       # MedicationAdministration.medicationCodeableConcept / medicationReference
       # MedicationDispense.medicationCodeableConcept / medicationReference
-      # MedicationRequest.medicationCodeableConcept / medicationReference
+      # MedicationRequest.medicationCodeableConcept / medicationReference -- in STU3
+      # MedicationOrder.medicationCodeableConcept / medicationReference -- in DSTU2
       # MedicationStatement.medicationCodeableConcept / medicationReference
 
       resources = record.entry.map{|e|e.resource}
       resources.each do |resource|
-        if resource.is_a?(FHIR::Medication)
+        if FHIR.is_any_version?(resource, 'Medication')
             results[:eligible_fields] += 1
             results[:validated_fields] += 1 if cvx?(resource.code)        
         elsif (
-            resource.is_a?(FHIR::MedicationRequest) ||
-            resource.is_a?(FHIR::MedicationDispense) ||
-            resource.is_a?(FHIR::MedicationAdministration) ||
-            resource.is_a?(FHIR::MedicationStatement) )
+            resource.is_a?(FHIR::MedicationRequest) || resource.is_a?(FHIR::DSTU2::MedicationOrder) ||
+            FHIR.is_any_version?(resource, 'MedicationDispense') ||
+            FHIR.is_any_version?(resource, 'MedicationAdministration') ||
+            FHIR.is_any_version?(resource, 'MedicationStatement') )
           if resource.medicationCodeableConcept
             results[:eligible_fields] += 1
             results[:validated_fields] += 1 if cvx?(resource.medicationCodeableConcept)
@@ -48,11 +49,11 @@ module FHIR
     def self.local_cvx_reference?(reference,record,contained)
       if contained && reference.reference && reference.reference.start_with?('#')
         contained.each do |resource|
-          return true if resource.is_a?(FHIR::Medication) && reference.reference[1..-1]==resource.id
+          return true if FHIR.is_any_version?(resource, 'Medication') && reference.reference[1..-1]==resource.id
         end
       end
       record.entry.each do |entry|
-        if entry.resource.is_a?(FHIR::Medication) && reference_matchs?(reference,entry)
+        if FHIR.is_any_version?(entry.resource, 'Medication') && reference_matchs?(reference,entry)
           return true
         end
       end

--- a/lib/rubrics/datetimes_iso8601.rb
+++ b/lib/rubrics/datetimes_iso8601.rb
@@ -45,9 +45,9 @@ module FHIR
           value = fhir_model.instance_variable_get("@#{field_name}")
           if !value.nil?
             if value.is_a?(Array)
-              value.each{|v| results.merge!(check_metadata(v)){|k,a,b|a+b} if v.is_a?(FHIR::Model)}
+              value.each{|v| results.merge!(check_metadata(v)){ |k,a,b| a + b } if FHIR.is_model?(v) }
             else # not an Array
-              results.merge!(check_metadata(value)){|k,a,b|a+b} if value.is_a?(FHIR::Model)
+              results.merge!(check_metadata(value)){ |k,a,b| a + b } if FHIR.is_model?(value)
             end
           end            
         end

--- a/lib/rubrics/labs_loinc.rb
+++ b/lib/rubrics/labs_loinc.rb
@@ -9,13 +9,13 @@ module FHIR
       }
       resources = record.entry.map{|e|e.resource}
       resources.each do |resource|
-        if resource.is_a?(FHIR::DiagnosticReport) || resource.is_a?(FHIR::Observation)
+        if FHIR.is_any_version?(resource, 'DiagnosticReport') || FHIR.is_any_version?(resource, 'Observation')
           results[:eligible_fields] += 1
           if resource.code
             results[:validated_fields] += 1 if resource.code.coding.any?{|x| x.system=='http://loinc.org' && FHIR::Terminology.is_top_lab_code?(x.code)}
           end
         end
-        if resource.is_a?(FHIR::Observation)
+        if FHIR.is_any_version?(resource, 'Observation')
           if resource.component
             resource.component.each do |comp|
               results[:eligible_fields] += 1

--- a/lib/rubrics/quantities_ucum.rb
+++ b/lib/rubrics/quantities_ucum.rb
@@ -5,11 +5,13 @@ module FHIR
       'TestScript','Task','StructureDefinition','SearchParameter','Questionnaire','QuestionnaireResponse','Parameters','OperationDefinition',
       'Group','ExplanationOfBenefit','Contract','Conformance','Claim','ActivityDefinition'
     ]
+    # Note: Task and ActivityDefinition don't exist in DSTU2
 
     CHECK = [
-      'VisionPrescription','SupplyDelivery','Substance','Specimen','Sequence','Observation','NutritionRequest',
-      'MedicationStatement','MedicationRequest','MedicationDispense','MedicationAdministration','Medication','Immunization','CarePlan'
+      'VisionPrescription','SupplyDelivery','Substance','Specimen','Sequence','Observation','NutritionOrder',
+      'MedicationStatement','MedicationRequest','MedicationOrder','MedicationDispense','MedicationAdministration','Medication','Immunization','CarePlan'
     ]
+    # Note: MedicationRequest renamed to MedicationOrder between 2->3; Sequence doesn't exist in DSTU2
 
     # Physical quantities should use UCUM
     rubric :ucum_quantities do |record|

--- a/lib/rubrics/references_resolve.rb
+++ b/lib/rubrics/references_resolve.rb
@@ -49,9 +49,9 @@ module FHIR
           value = fhir_model.instance_variable_get("@#{field_name}")
           if !value.nil?
             if value.is_a?(Array)
-              value.each{|v| results.merge!(check_metadata(v,record)){|k,a,b|a+b} if v.is_a?(FHIR::Model)}
+              value.each{ |v| results.merge!(check_metadata(v, record)){ |k,a,b| a + b } if FHIR.is_model?(v) }
             else # not an Array
-              results.merge!(check_metadata(value,record)){|k,a,b|a+b} if value.is_a?(FHIR::Model)
+              results.merge!(check_metadata(value, record)){ |k,a,b| a + b } if FHIR.is_model?(value)
             end
           end            
         end

--- a/lib/rubrics/smoking_status.rb
+++ b/lib/rubrics/smoking_status.rb
@@ -17,7 +17,7 @@ module FHIR
       
       resources = record.entry.map{|e|e.resource}
       has_smoking_status = resources.any? do |resource|
-        resource.is_a?(FHIR::Observation) && smoking_observation?(resource)
+        FHIR.is_any_version?(resource, 'Observation') && smoking_observation?(resource)
       end
 
       if has_smoking_status

--- a/lib/rubrics/snomed_conditions.rb
+++ b/lib/rubrics/snomed_conditions.rb
@@ -10,7 +10,7 @@ module FHIR
 
       resources = record.entry.map{|e|e.resource}
       resources.each do |resource|
-        if resource.is_a?(FHIR::Condition)
+        if FHIR.is_any_version?(resource, 'Condition')
           results[:eligible_fields] += 1
           results[:validated_fields] += 1 if snomed_core?(resource.code)
         end

--- a/lib/rubrics/vital_signs.rb
+++ b/lib/rubrics/vital_signs.rb
@@ -25,7 +25,7 @@ module FHIR
 
       resources = record.entry.map{|e|e.resource}
       resources.each do |resource|
-        if resource.is_a?(FHIR::Observation)
+        if FHIR.is_any_version?(resource, 'Observation')
           found_code = get_vital_code(resource.code)
           components = not_found[ found_code ]
           if components.nil?

--- a/lib/terminology.rb
+++ b/lib/terminology.rb
@@ -25,6 +25,16 @@ module FHIR
     @@core_snomed = {}
     @@common_ucum = []
 
+    def self.reset
+      @@loaded = false
+      @@top_lab_code_units = {}
+      @@top_lab_code_descriptions = {}
+      @@known_codes = {}
+      @@core_snomed = {}
+      @@common_ucum = []
+    end
+    private_class_method :reset
+
     def self.set_terminology_root(root)
       @@term_root = root
     end

--- a/test/unit/basic_test.rb
+++ b/test/unit/basic_test.rb
@@ -5,19 +5,50 @@ class BasicTest < Minitest::Test
   # turn off the ridiculous warnings
   $VERBOSE=nil
 
-  def test_bundle
+  def test_bundle_text_stu3
     bundle = FHIR::Bundle.new
     scorecard = FHIR::Scorecard.new
     report = scorecard.score(bundle.to_json)
     
-    assert (report[:points]), 'Scorecard should report points.'
-    assert (report[:bundle]), 'Scorecard should report Bundle section.'
-    assert (report[:patient]), 'Scorecard should report Patient section.'
-    assert (report[:points]==10), 'Scorecard points incorrect.'
-    assert (report[:bundle][:points]), 'Bundle section should report points.'
-    assert (report[:bundle][:points]==10), 'Bundle section points incorrect.'
-    assert (report[:patient][:points]), 'Patient section should report points.'
-    assert (report[:patient][:points]==0), 'Patient section points incorrect.'
+    verify_empty_bundle_report(report)
+  end
+
+  def test_bundle_object_stu3
+    bundle = FHIR::Bundle.new
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+
+    verify_empty_bundle_report(report)
+  end
+
+  def test_bundle_stu3_specified
+    bundle = FHIR::Bundle.new
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle.to_json, 'STU3')
+    
+    verify_empty_bundle_report(report)
+  end
+
+  def test_bundle_text_dstu2
+    bundle = FHIR::DSTU2::Bundle.new
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle.to_json, 'DSTU2')
+    
+    verify_empty_bundle_report(report)
+  end
+  
+  def test_bundle_object_dstu2
+    bundle = FHIR::DSTU2::Bundle.new
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+
+    verify_empty_bundle_report(report)
+  end
+
+  def test_invalid_version_specified
+    bundle = FHIR::Bundle.new
+    scorecard = FHIR::Scorecard.new
+    assert_raises(RuntimeError) { scorecard.score(bundle.to_json, 'badversion') }
   end
 
   def test_not_bundle
@@ -32,7 +63,7 @@ class BasicTest < Minitest::Test
     assert (report[:bundle][:points]==0), 'Bundle section points incorrect.'
   end
 
-  def test_bundle_with_patient
+  def test_bundle_with_patient_stu3
     patient = FHIR::Patient.new
     bundle = FHIR::Bundle.new({'entry'=>[ {} ]})
     bundle.entry.first.resource = patient
@@ -47,6 +78,18 @@ class BasicTest < Minitest::Test
     assert (report[:bundle][:points]==10), 'Bundle section points incorrect.'
     assert (report[:patient][:points]), 'Patient section should report points.'
     assert (report[:patient][:points]==10), 'Patient section points incorrect.'
+  end
+
+
+  def verify_empty_bundle_report(report)
+    assert (report[:points]), 'Scorecard should report points.'
+    assert (report[:bundle]), 'Scorecard should report Bundle section.'
+    assert (report[:patient]), 'Scorecard should report Patient section.'
+    assert (report[:points]==10), 'Scorecard points incorrect.'
+    assert (report[:bundle][:points]), 'Bundle section should report points.'
+    assert (report[:bundle][:points]==10), 'Bundle section points incorrect.'
+    assert (report[:patient][:points]), 'Patient section should report points.'
+    assert (report[:patient][:points]==0), 'Patient section points incorrect.'
   end
 
 end

--- a/test/unit/basic_test.rb
+++ b/test/unit/basic_test.rb
@@ -30,7 +30,7 @@ class BasicTest < Minitest::Test
   end
 
   def test_bundle_text_dstu2
-    bundle = FHIR::DSTU2::Bundle.new
+    bundle = FHIR::DSTU2::Bundle.new('type' => 'collection')
     scorecard = FHIR::Scorecard.new
     report = scorecard.score(bundle.to_json, 'DSTU2')
     

--- a/test/unit/codes_exist_test.rb
+++ b/test/unit/codes_exist_test.rb
@@ -140,7 +140,7 @@ class CodesExistTest < Minitest::Test
   end
 
   def test_codes_exist_none_dstu2
-    patient = FHIR::DSTU2::Patient.new
+    patient = FHIR::DSTU2::Patient.new( 'active' => true )
     bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
     scorecard = FHIR::Scorecard.new
     report = scorecard.score(bundle)

--- a/test/unit/codes_exist_test.rb
+++ b/test/unit/codes_exist_test.rb
@@ -5,43 +5,34 @@ class CodesExistTest < Minitest::Test
   # turn off the ridiculous warnings
   $VERBOSE=nil
 
-  def test_codes_exist_none
+  def test_codes_exist_none_stu3
     patient = FHIR::Patient.new
     bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
     scorecard = FHIR::Scorecard.new
-    report = scorecard.score(bundle.to_json)
-    assert (report[:points]), 'Scorecard should report points.'
-    assert (report[:bundle]), 'Scorecard should report Bundle section.'
-    assert (report[:patient]), 'Scorecard should report Patient section.'
-    assert (report[:codes_exist]), 'Scorecard should report Codes Exist section.'
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
     assert (report[:codes_exist][:points]==0), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=0)."
   end
 
-  def test_codes_exist_1of3
+  def test_codes_exist_1of3_stu3
     patient = FHIR::Patient.new({ 'gender'=>'male' })
     bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
     scorecard = FHIR::Scorecard.new
-    report = scorecard.score(bundle.to_json)
-    assert (report[:points]), 'Scorecard should report points.'
-    assert (report[:bundle]), 'Scorecard should report Bundle section.'
-    assert (report[:patient]), 'Scorecard should report Patient section.'
-    assert (report[:codes_exist]), 'Scorecard should report Codes Exist section.'
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
     assert (report[:codes_exist][:points]==3), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=3)."
   end
 
-  def test_codes_exist_1of3_wrongtype
+  def test_codes_exist_1of3_wrongtype_stu3
     patient = FHIR::Patient.new({ 'gender'=>0 })
     bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
     scorecard = FHIR::Scorecard.new
-    report = scorecard.score(bundle.to_json)
-    assert (report[:points]), 'Scorecard should report points.'
-    assert (report[:bundle]), 'Scorecard should report Bundle section.'
-    assert (report[:patient]), 'Scorecard should report Patient section.'
-    assert (report[:codes_exist]), 'Scorecard should report Codes Exist section.'
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
     assert (report[:codes_exist][:points]==0), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=0)."
   end
 
-  def test_codes_exist_2of3
+  def test_codes_exist_2of3_stu3
     patient = FHIR::Patient.new({ 
       'gender'=>'male', 
       'maritalStatus'=> { 
@@ -50,15 +41,12 @@ class CodesExistTest < Minitest::Test
     })
     bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
     scorecard = FHIR::Scorecard.new
-    report = scorecard.score(bundle.to_json)
-    assert (report[:points]), 'Scorecard should report points.'
-    assert (report[:bundle]), 'Scorecard should report Bundle section.'
-    assert (report[:patient]), 'Scorecard should report Patient section.'
-    assert (report[:codes_exist]), 'Scorecard should report Codes Exist section.'
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
     assert (report[:codes_exist][:points]==6), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=6)."
   end
 
-  def test_codes_exist_2of3_textonly
+  def test_codes_exist_2of3_textonly_stu3
     patient = FHIR::Patient.new({ 
       'gender'=>'male', 
       'maritalStatus'=> { 
@@ -67,15 +55,12 @@ class CodesExistTest < Minitest::Test
     })
     bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
     scorecard = FHIR::Scorecard.new
-    report = scorecard.score(bundle.to_json)
-    assert (report[:points]), 'Scorecard should report points.'
-    assert (report[:bundle]), 'Scorecard should report Bundle section.'
-    assert (report[:patient]), 'Scorecard should report Patient section.'
-    assert (report[:codes_exist]), 'Scorecard should report Codes Exist section.'
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
     assert (report[:codes_exist][:points]==3), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=3)."
   end
 
-  def test_codes_exist_3of3
+  def test_codes_exist_3of3_stu3
     patient = FHIR::Patient.new({ 
       'language'=>'en-US',
       'gender'=>'male', 
@@ -85,15 +70,12 @@ class CodesExistTest < Minitest::Test
     })
     bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
     scorecard = FHIR::Scorecard.new
-    report = scorecard.score(bundle.to_json)
-    assert (report[:points]), 'Scorecard should report points.'
-    assert (report[:bundle]), 'Scorecard should report Bundle section.'
-    assert (report[:patient]), 'Scorecard should report Patient section.'
-    assert (report[:codes_exist]), 'Scorecard should report Codes Exist section.'
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
     assert (report[:codes_exist][:points]==10), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=10)."
   end
 
-  def test_codes_exist_with_backbone_elements
+  def test_codes_exist_with_backbone_elements_stu3
     patient = FHIR::Patient.new({ 
       'language'=>'en-US',
       'gender'=>'male', 
@@ -113,15 +95,12 @@ class CodesExistTest < Minitest::Test
     })
     bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
     scorecard = FHIR::Scorecard.new
-    report = scorecard.score(bundle.to_json)
-    assert (report[:points]), 'Scorecard should report points.'
-    assert (report[:bundle]), 'Scorecard should report Bundle section.'
-    assert (report[:patient]), 'Scorecard should report Patient section.'
-    assert (report[:codes_exist]), 'Scorecard should report Codes Exist section.'
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
     assert (report[:codes_exist][:points]==10), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=10)."
   end
 
-  def test_codes_exist_with_backbone_elements_and_array
+  def test_codes_exist_with_backbone_elements_and_array_stu3
     patient = FHIR::Patient.new({ 
       'language'=>'en-US',
       'gender'=>'male', 
@@ -142,15 +121,12 @@ class CodesExistTest < Minitest::Test
     })
     bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
     scorecard = FHIR::Scorecard.new
-    report = scorecard.score(bundle.to_json)
-    assert (report[:points]), 'Scorecard should report points.'
-    assert (report[:bundle]), 'Scorecard should report Bundle section.'
-    assert (report[:patient]), 'Scorecard should report Patient section.'
-    assert (report[:codes_exist]), 'Scorecard should report Codes Exist section.'
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
     assert (report[:codes_exist][:points]==10), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=10)."
   end
 
-  def test_codes_exist_with_coding
+  def test_codes_exist_with_coding_stu3
     encounter = FHIR::Encounter.new({ 
       'language'=>'en-US',
       'status'=>'planned',
@@ -158,12 +134,149 @@ class CodesExistTest < Minitest::Test
     })
     bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => encounter.to_hash } ] })
     scorecard = FHIR::Scorecard.new
-    report = scorecard.score(bundle.to_json)
-    assert (report[:points]), 'Scorecard should report points.'
-    assert (report[:bundle]), 'Scorecard should report Bundle section.'
-    assert (report[:patient]), 'Scorecard should report Patient section.'
-    assert (report[:codes_exist]), 'Scorecard should report Codes Exist section.'
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
     assert (report[:codes_exist][:points]==5), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=5)."
+  end
+
+  def test_codes_exist_none_dstu2
+    patient = FHIR::DSTU2::Patient.new
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
+    assert (report[:codes_exist][:points]==0), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=0)."
+  end
+
+  def test_codes_exist_1of3_dstu2
+    patient = FHIR::DSTU2::Patient.new({ 'gender'=>'male' })
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
+    assert (report[:codes_exist][:points]==3), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=3)."
+  end
+
+  def test_codes_exist_1of3_wrongtype_dstu2
+    patient = FHIR::DSTU2::Patient.new({ 'gender'=>0 })
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
+    assert (report[:codes_exist][:points]==0), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=0)."
+  end
+
+  def test_codes_exist_2of3_dstu2
+    patient = FHIR::DSTU2::Patient.new({ 
+      'gender'=>'male', 
+      'maritalStatus'=> { 
+        'coding'=>[ {'code'=>'S','system'=>'http://hl7.org/fhir/v3/MaritalStatus'} ]
+      } 
+    })
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
+    assert (report[:codes_exist][:points]==6), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=6)."
+  end
+
+  def test_codes_exist_2of3_textonly_dstu2
+    patient = FHIR::DSTU2::Patient.new({ 
+      'gender'=>'male', 
+      'maritalStatus'=> { 
+        'text'=>'Single'
+      } 
+    })
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
+    assert (report[:codes_exist][:points]==3), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=3)."
+  end
+
+  def test_codes_exist_3of3_dstu2
+    patient = FHIR::DSTU2::Patient.new({ 
+      'language'=>'en-US',
+      'gender'=>'male', 
+      'maritalStatus'=> { 
+        'coding'=>[ {'code'=>'S','system'=>'http://hl7.org/fhir/v3/MaritalStatus'} ]
+      } 
+    })
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
+    assert (report[:codes_exist][:points]==10), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=10)."
+  end
+
+  def test_codes_exist_with_backbone_elements_dstu2
+    patient = FHIR::DSTU2::Patient.new({ 
+      'language'=>'en-US',
+      'gender'=>'male', 
+      'maritalStatus'=> { 
+        'coding'=>[ {'code'=>'S','system'=>'http://hl7.org/fhir/v3/MaritalStatus'} ]
+      },
+      'communication'=> [
+        { 'language'=> { 
+            'coding'=>[ {'code'=>'en-US','system'=>'urn:ietf:bcp:47'} ]
+          }, 
+          'preferred'=> true },
+        { 'language'=> { 
+            'coding'=>[ {'code'=>'es','system'=>'urn:ietf:bcp:47'} ]
+          }
+        }
+      ]
+    })
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
+    assert (report[:codes_exist][:points]==10), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=10)."
+  end
+
+  def test_codes_exist_with_backbone_elements_and_array_dstu2
+    patient = FHIR::DSTU2::Patient.new({ 
+      'language'=>'en-US',
+      'gender'=>'male', 
+      'maritalStatus'=> { 
+        'coding'=>[ {'code'=>'S','system'=>'http://hl7.org/fhir/v3/MaritalStatus'} ]
+      },
+      'contact'=> [
+        { 'gender'=>'male',
+          'relationship'=> [
+            {  'coding'=>[ {'code'=>'c','system'=>'http://hl7.org/fhir/v2/0131'} ] }
+          ]
+        },{ 'gender'=>'female',
+          'relationship'=> [
+            {  'coding'=>[ {'code'=>'n','system'=>'http://hl7.org/fhir/v2/0131'} ] }
+          ]
+        }
+      ] 
+    })
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
+    assert (report[:codes_exist][:points]==10), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=10)."
+  end
+
+  def test_codes_exist_with_coding_dstu2
+    encounter = FHIR::DSTU2::Encounter.new({ 
+      'language'=>'en-US',
+      'status'=>'planned',
+      'class'=>'ambulatory'
+    })
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => encounter.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :codes_exist)
+    assert (report[:codes_exist][:points]==5), "Codes Exist section points incorrect (#{report[:codes_exist][:points]}!=5)."
+  end
+
+  def assert_sections_exist(report, *sections)
+    sections.each do |section|
+      assert(report[section], "Scorecard should report #{section} section.")
+    end
   end
 
 end

--- a/test/unit/completeness_test.rb
+++ b/test/unit/completeness_test.rb
@@ -55,7 +55,7 @@ class CompletenessTest < Minitest::Test
   end
 
   def test_empty_record_dstu2
-    patient = FHIR::DSTU2::Patient.new
+    patient = FHIR::DSTU2::Patient.new( 'active' => true )
     bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
     scorecard = FHIR::Scorecard.new
     report = scorecard.score(bundle)
@@ -65,7 +65,7 @@ class CompletenessTest < Minitest::Test
   end
 
   def test_1_required_dstu2
-    patient = FHIR::DSTU2::Patient.new
+    patient = FHIR::DSTU2::Patient.new( 'active' => true )
     condition = FHIR::DSTU2::Condition.new('code' => { 'coding' => { 'code' => '254230001', 'system'=> 'http://snomed.info/sct' } })
     bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash }, { 'resource' => condition.to_hash } ] })
     scorecard = FHIR::Scorecard.new
@@ -76,15 +76,15 @@ class CompletenessTest < Minitest::Test
   end
 
   def test_1_expected_dstu2
-    patient = FHIR::DSTU2::Patient.new
-    vis_pres = FHIR::DSTU2::VisionPrescription.new
+    patient = FHIR::DSTU2::Patient.new( 'active' => true )
+    vis_pres = FHIR::DSTU2::VisionPrescription.new( 'dateWritten' => '2017-01-01')
     appt = FHIR::DSTU2::Appointment.new( 'status' => 'fulfilled' )
-    device = FHIR::DSTU2::DeviceUseStatement.new( 'status' => 'active' )
+    device = FHIR::DSTU2::DeviceUseStatement.new( 'recordedOn' => '2017-01-01')
     bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash }, 
                                            { 'resource' => appt.to_hash },
                                            { 'resource' => device.to_hash },
                                            { 'resource' => vis_pres.to_hash }, # intentionally including the VisionPrescription twice
-                                           { 'resource' => vis_pres.to_hash }, ] }) 
+                                           { 'resource' => vis_pres.to_hash } ] })
     scorecard = FHIR::Scorecard.new
     report = scorecard.score(bundle)
     assert_sections_exist(report, :points, :bundle, :patient, :completeness)
@@ -93,7 +93,7 @@ class CompletenessTest < Minitest::Test
   end
 
   def test_medication_dstu2
-    patient = FHIR::DSTU2::Patient.new
+    patient = FHIR::DSTU2::Patient.new( 'active' => true )
     med_order = FHIR::DSTU2::MedicationOrder.new('medicationCodeableConcept' => { 'coding' => { 'code'=>'161', 'system'=> 'http://www.nlm.nih.gov/research/umls/rxnorm'}})
     bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash }, { 'resource' => med_order.to_hash } ] })
     scorecard = FHIR::Scorecard.new

--- a/test/unit/completeness_test.rb
+++ b/test/unit/completeness_test.rb
@@ -1,0 +1,111 @@
+require_relative '../test_helper'
+
+class CompletenessTest < Minitest::Test
+
+  # turn off the ridiculous warnings
+  $VERBOSE=nil
+
+  def test_empty_record_stu3
+    patient = FHIR::Patient.new
+    bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :completeness)
+    # expected points = 0, because they have no required or expected elements
+    assert_equal(0, report[:completeness][:points], "Completeness section points incorrect.")
+  end
+
+  def test_1_required_stu3
+    patient = FHIR::Patient.new
+    condition = FHIR::Condition.new('code' => { 'coding' => { 'code' => '254230001', 'system'=> 'http://snomed.info/sct' } })
+    bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash }, { 'resource' => condition.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :completeness)
+    # expected points = 2 because 1/7 * 20 gets truncated to 2
+    assert_equal(2, report[:completeness][:points], "Completeness section points incorrect.")
+  end
+
+  def test_1_expected_stu3
+    patient = FHIR::Patient.new
+    vis_pres = FHIR::VisionPrescription.new
+    appt = FHIR::Appointment.new( 'status' => 'fulfilled' )
+    device = FHIR::DeviceUseStatement.new( 'status' => 'active' )
+    bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash }, 
+                                           { 'resource' => appt.to_hash },
+                                           { 'resource' => device.to_hash },
+                                           { 'resource' => vis_pres.to_hash }, # intentionally including the VisionPrescription twice
+                                           { 'resource' => vis_pres.to_hash }, ] }) 
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :completeness)
+    # expected points = 1 because 3 present of 11 expected * 5.0 points... 3/11 * 5 gets truncated to 1
+    assert_equal(1, report[:completeness][:points], "Completeness section points incorrect.")
+  end
+
+  def test_medication_stu3
+    patient = FHIR::Patient.new
+    med_order = FHIR::MedicationRequest.new('medicationCodeableConcept' => { 'coding' => { 'code'=>'161', 'system'=> 'http://www.nlm.nih.gov/research/umls/rxnorm'}})
+    bundle = FHIR::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash }, { 'resource' => med_order.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :completeness)
+    # expected points = 2 because 1/7 * 20 gets truncated to 2
+    assert_equal(2, report[:completeness][:points], "Completeness section points incorrect.")    
+  end
+
+  def test_empty_record_dstu2
+    patient = FHIR::DSTU2::Patient.new
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :completeness)
+    # expected points = 0, because they have no required or expected elements
+    assert_equal(0, report[:completeness][:points], "Completeness section points incorrect.")
+  end
+
+  def test_1_required_dstu2
+    patient = FHIR::DSTU2::Patient.new
+    condition = FHIR::DSTU2::Condition.new('code' => { 'coding' => { 'code' => '254230001', 'system'=> 'http://snomed.info/sct' } })
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash }, { 'resource' => condition.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :completeness)
+    # expected points = 2 because 1/7 * 20 gets truncated to 2
+    assert_equal(2, report[:completeness][:points], "Completeness section points incorrect.")
+  end
+
+  def test_1_expected_dstu2
+    patient = FHIR::DSTU2::Patient.new
+    vis_pres = FHIR::DSTU2::VisionPrescription.new
+    appt = FHIR::DSTU2::Appointment.new( 'status' => 'fulfilled' )
+    device = FHIR::DSTU2::DeviceUseStatement.new( 'status' => 'active' )
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash }, 
+                                           { 'resource' => appt.to_hash },
+                                           { 'resource' => device.to_hash },
+                                           { 'resource' => vis_pres.to_hash }, # intentionally including the VisionPrescription twice
+                                           { 'resource' => vis_pres.to_hash }, ] }) 
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :completeness)
+    # expected points = 1 because 3 present of 11 expected * 5.0 points... 3/11 * 5 gets truncated to 1
+    assert_equal(1, report[:completeness][:points], "Completeness section points incorrect.")
+  end
+
+  def test_medication_dstu2
+    patient = FHIR::DSTU2::Patient.new
+    med_order = FHIR::DSTU2::MedicationOrder.new('medicationCodeableConcept' => { 'coding' => { 'code'=>'161', 'system'=> 'http://www.nlm.nih.gov/research/umls/rxnorm'}})
+    bundle = FHIR::DSTU2::Bundle.new({ 'entry'=>[ { 'resource' => patient.to_hash }, { 'resource' => med_order.to_hash } ] })
+    scorecard = FHIR::Scorecard.new
+    report = scorecard.score(bundle)
+    assert_sections_exist(report, :points, :bundle, :patient, :completeness)
+    # expected points = 2 because 1/7 * 20 gets truncated to 2
+    assert_equal(2, report[:completeness][:points], "Completeness section points incorrect.")    
+  end
+
+  def assert_sections_exist(report, *sections)
+    sections.each do |section|
+      assert(report[section], "Scorecard should report #{section} section.")
+    end
+  end
+end

--- a/test/unit/fhir_helper_test.rb
+++ b/test/unit/fhir_helper_test.rb
@@ -1,0 +1,31 @@
+require_relative '../test_helper'
+
+class FHIRHelperTest < Minitest::Test
+  def test_is_any_version
+    object = FHIR::Patient.new
+    assert(FHIR.is_any_version?(object, 'Patient'))
+    refute(FHIR.is_any_version?(object, 'Bundle'))
+
+    object = FHIR::DSTU2::Patient.new
+    assert(FHIR.is_any_version?(object, 'Patient'))
+    refute(FHIR.is_any_version?(object, 'Bundle'))
+
+    object = FHIR::Bundle.new
+    assert(FHIR.is_any_version?(object, 'Bundle'))
+    refute(FHIR.is_any_version?(object, 'Patient'))
+
+    object = FHIR::DSTU2::Bundle.new
+    assert(FHIR.is_any_version?(object, 'Bundle'))
+    refute(FHIR.is_any_version?(object, 'Patient'))
+    
+    object = FHIR::MedicationRequest.new # class only exists in 3, not 2
+    assert(FHIR.is_any_version?(object, 'MedicationRequest'))
+    refute(FHIR.is_any_version?(object, 'MedicationOrder'))
+
+    object = FHIR::DSTU2::MedicationOrder.new # class only exists in 2, not 3
+    assert(FHIR.is_any_version?(object, 'MedicationOrder'))
+    refute(FHIR.is_any_version?(object, 'MedicationRequest'))
+
+    refute(FHIR.is_any_version?(object, 'ThisClassDoesNotExistAnywhere'))
+  end
+end

--- a/test/unit/terminology_test.rb
+++ b/test/unit/terminology_test.rb
@@ -8,6 +8,7 @@ class TerminologyTest < Minitest::Test
   @@term_root = File.expand_path '../../terminology',File.dirname(File.absolute_path(__FILE__))
 
   def setup
+    FHIR::Terminology.send(:reset)
     loinc_file = File.join(@@term_root,'scorecard_loinc_2000.txt')
     umls_file = File.join(@@term_root,'scorecard_umls.txt')
     snomed_file = File.join(@@term_root,'scorecard_snomed_core.txt')
@@ -36,7 +37,8 @@ class TerminologyTest < Minitest::Test
     FileUtils.rm(snomed_file, :force=>true)
     FileUtils.mv("#{loinc_file}.bak",loinc_file, :force=>true)
     FileUtils.mv("#{umls_file}.bak",umls_file, :force=>true)
-    FileUtils.mv("#{snomed_file}.bak",snomed_file, :force=>true)    
+    FileUtils.mv("#{snomed_file}.bak",snomed_file, :force=>true)
+    FHIR::Terminology.send(:reset)
   end
 
   def test_get_description_foo


### PR DESCRIPTION
Adds DSTU2 support to the scorecard, so that now both DSTU2 and STU3 are concurrently supported. The main way this is implemented is with a helper function `is_any_version?` which takes an object and a classname and checks if the object is an instance of that class within the FHIR and FHIR::DSTU2 namespaces. Where previously objects were checked `object.is_a?(FHIR:Abc)` now they should be checked `FHIR::is_any_version?(object, 'Abc')` .
There are a few classes which changed or were introduced between DSTU2 and STU3 but the only one of any significance here is MedicationOrder -> MedicationRequest.

The main entry point to the scorecard was also updated to take the FHIR version of the passed-in bundle json as an optional parameter. If no version is passed in then it assumes STU3 (to maintain the current behavior). Alternatively the scorecard can be passed a bundle object directly, in which case it will use the right FHIR version implicitly.